### PR TITLE
AD-HOC feat (Prometheus): Render configuration to disk

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -9,3 +9,18 @@
   vars:
     __prometheus__args: "{{ prometheus__server_args }}"
   notify: "restart prometheus-server"
+
+- name: "Create the etc directory"
+  file:
+    path: "/etc/prometheus"
+    state: "directory"
+    owner: "root"
+    group: "root"
+    mode: "u=rwx,g=rx,o=rx"
+
+- name: "Render the system configuration"
+  template:
+    src: "etc/prometheus/prometheus.yml"
+    dest: "/etc/prometheus/prometheus.yml"
+    owner: "root"
+    mode: "u=r,g=r,o="

--- a/templates/etc/prometheus/prometheus.yml
+++ b/templates/etc/prometheus/prometheus.yml
@@ -1,0 +1,44 @@
+# Configuration for Prometheus
+# yamllint disable
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+      monitor: 'example'
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets: ['localhost:9093']
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+    scrape_timeout: 5s
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: node
+    # If prometheus-node-exporter is installed, grab stats about the local
+    # machine by default.
+    static_configs:
+      - targets: ['localhost:9100']


### PR DESCRIPTION
Prometheus configuration should regularly be customized to modify the
way the monitoring tool scrapes the services it is responsible for.

This commit takes the first step towards this by rendering the default
configuration in the appropriate place.