### PR TITLE
AD-HOC feat (Prometheus): Add system user, configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     playbook: test.yml
   - distro: ubuntu1604
     playbook: test.yml
-  - distro: ubuntu18.04
+  - distro: ubuntu1804
     playbook: test.yml
 
 script:

--- a/tasks/install-server/binary.yml
+++ b/tasks/install-server/binary.yml
@@ -1,6 +1,14 @@
 ---
 # Binary installation
 # Used when the system has no packages available
+- name: "Ensure the system user is available"
+  user:
+    name: "prometheus"
+    comment: "Prometheus Daemon"
+    home: "/var/lib/prometheus"
+    system: "yes"
+    shell: "/usr/sbin/nologin"
+
 - name: "Determine if the correct server binary is already installed"
   stat:
     path: "/usr/local/bin/prometheus"

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -22,5 +22,6 @@
   template:
     src: "etc/prometheus/prometheus.yml"
     dest: "/etc/prometheus/prometheus.yml"
-    owner: "root"
+    owner: "prometheus"
+    group: "prometheus"
     mode: "u=r,g=r,o="


### PR DESCRIPTION
Currently there is a problem in which Prometheus is unable to read the
configuration as Prometheus when installed via apt is being run as
"Prometheus" and not as root, but the configuration is owned by root.

This commit modifies binary installation to also run as "prometheus",
and the configuration to be owned by this user.