### PR TITLE
AD-HOC refactor (Variables): Rename variables to include vendor prefix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 ## See
 ##  $ prometheus --help
 ##
-prometheus__server_args:
+sitewards__prometheus__server_args:
   ## Bound to 127.0.0.1 as if it's required to federate, it's expected that another service will handle TLS and
   ## authentication
   ##
@@ -16,7 +16,7 @@ prometheus__server_args:
 ## See
 ##  $ prometheus-node-exporter --help
 ##
-prometheus__node_exporter_args:
+sitewards__prometheus__node_exporter_args:
   ## Bound to localhost as it's expected metrics will be exfilled by the federated Prometheus
   - '--web.listen-address="127.0.0.1:9100"'
   - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/)'
@@ -28,25 +28,25 @@ prometheus__node_exporter_args:
 ## See
 ##   https://github.com/prometheus/prometheus/releases/
 ##
-prometheus__server_binary_version: "2.3.0"
+sitewards__prometheus__server_binary_version: "2.3.0"
 
 ## The SHA 256 sum of the binary that should be installed
 ##
 ## See
 ##   https://github.com/prometheus/prometheus/releases/
 ##
-prometheus__server_binary_sha256sum: "f806357db68a493ebd0ef24bb3cca550ee245831b306bde055253513bcb93496"
+sitewards__prometheus__server_binary_sha256sum: "f806357db68a493ebd0ef24bb3cca550ee245831b306bde055253513bcb93496"
 
 ## The version of the binary to install
 ##
 ## See
 ##   https://github.com/prometheus/node_exporter/releases
 ##
-prometheus__node_exporter_binary_version: "0.16.0"
+sitewards__prometheus__node_exporter_binary_version: "0.16.0"
 
 ## The SHA 256 sum of the binary that should be installed
 ##
 ## See
 ##   https://github.com/prometheus/node_exporter/releases
 ##
-prometheus__node_exporter_binary_sha256sum: "29606320aac8375889bb74ac15de91484fb126c2a847f4a30d5dbf972c4675bd"
+sitewards__prometheus__node_exporter_binary_sha256sum: "29606320aac8375889bb74ac15de91484fb126c2a847f4a30d5dbf972c4675bd"

--- a/tasks/install-node-exporter/apt.yml
+++ b/tasks/install-node-exporter/apt.yml
@@ -9,5 +9,5 @@
     src: "etc/default/defaults.j2"
     dest: "/etc/default/prometheus-node-exporter"
   vars:
-    __prometheus__args: "{{ prometheus__node_exporter_args }}"
+    __sitewards__prometheus__args: "{{ sitewards__prometheus__node_exporter_args }}"
   notify: "restart prometheus-node-exporter"

--- a/tasks/install-node-exporter/binary.yml
+++ b/tasks/install-node-exporter/binary.yml
@@ -18,7 +18,7 @@
     __prometheus_node_exporter_installed: true
   when:
     - "__stat_prometheus_node_exporter.stat.exists == true"
-    - "__stat_prometheus_node_exporter.stat.checksum == prometheus__node_exporter_binary_sha256sum"
+    - "__stat_prometheus_node_exporter.stat.checksum == sitewards__prometheus__node_exporter_binary_sha256sum"
 
 - name: "Create a working directory for installation"
   tempfile:
@@ -29,7 +29,7 @@
 
 - name: "Download the appropriate node exporter version"
   unarchive:
-    src: "https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus__node_exporter_binary_version }}/node_exporter-{{ prometheus__node_exporter_binary_version }}.linux-amd64.tar.gz"
+    src: "https://github.com/prometheus/node_exporter/releases/download/v{{ sitewards__prometheus__node_exporter_binary_version }}/node_exporter-{{ sitewards__prometheus__node_exporter_binary_version }}.linux-amd64.tar.gz"
     dest: "{{ __prometheus_node_exporter_install_workdir.path }}"
     remote_src: true
   when:
@@ -37,7 +37,7 @@
 
 - name: "Get the hash of the downloaded binary"
   stat:
-    path: "{{ __prometheus_node_exporter_install_workdir.path }}/node_exporter-{{ prometheus__node_exporter_binary_version }}.linux-amd64/node_exporter"
+    path: "{{ __prometheus_node_exporter_install_workdir.path }}/node_exporter-{{ sitewards__prometheus__node_exporter_binary_version }}.linux-amd64/node_exporter"
     checksum_algorithm: "sha256"
   register: "__stat_prometheus_node_exporter_download"
   when:
@@ -47,11 +47,11 @@
     msg: "The checksum verification failed for the downloaded prometheus server"
   when:
     - "__prometheus_node_exporter_installed == false"
-    - "__stat_prometheus_node_exporter_download.stat.checksum != prometheus__node_exporter_binary_sha256sum"
+    - "__stat_prometheus_node_exporter_download.stat.checksum != sitewards__prometheus__node_exporter_binary_sha256sum"
 
 - name: "Install the Node Exporter"
   copy:
-    src: "{{ __prometheus_node_exporter_install_workdir.path }}/node_exporter-{{ prometheus__node_exporter_binary_version }}.linux-amd64/node_exporter"
+    src: "{{ __prometheus_node_exporter_install_workdir.path }}/node_exporter-{{ sitewards__prometheus__node_exporter_binary_version }}.linux-amd64/node_exporter"
     dest: "/usr/local/bin/node_exporter"
     owner: "root"
     group: "root"

--- a/tasks/install-server/binary.yml
+++ b/tasks/install-server/binary.yml
@@ -26,7 +26,7 @@
     __prometheus_server_installed: true
   when:
     - "__stat_prometheus_server.stat.exists == true"
-    - "__stat_prometheus_server.stat.checksum == prometheus__server_binary_sha256sum"
+    - "__stat_prometheus_server.stat.checksum == sitewards__prometheus__server_binary_sha256sum"
 
 - name: "Create a working directory for installatino"
   tempfile:
@@ -37,7 +37,7 @@
 
 - name: "Download the appropriate prometheus version"
   unarchive:
-    src: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus__server_binary_version }}/prometheus-{{ prometheus__server_binary_version }}.linux-amd64.tar.gz"
+    src: "https://github.com/prometheus/prometheus/releases/download/v{{ sitewards__prometheus__server_binary_version }}/prometheus-{{ sitewards__prometheus__server_binary_version }}.linux-amd64.tar.gz"
     dest: "{{ __prometheus_server_install_workdir.path }}"
     remote_src: true
   when:
@@ -45,7 +45,7 @@
 
 - name: "Get the hash of the downloaded binary"
   stat:
-    path: "{{ __prometheus_server_install_workdir.path }}/prometheus-{{ prometheus__server_binary_version }}.linux-amd64/prometheus"
+    path: "{{ __prometheus_server_install_workdir.path }}/prometheus-{{ sitewards__prometheus__server_binary_version }}.linux-amd64/prometheus"
     checksum_algorithm: "sha256"
   register: "__stat_prometheus_server_download"
   when:
@@ -55,11 +55,11 @@
     msg: "The checksum verification failed for the downloaded prometheus server"
   when:
     - "__prometheus_server_installed == false"
-    - "__stat_prometheus_server_download.stat.checksum != prometheus__server_binary_sha256sum"
+    - "__stat_prometheus_server_download.stat.checksum != sitewards__prometheus__server_binary_sha256sum"
 
 - name: "Install prometheus"
   copy:
-    src: "{{ __prometheus_server_install_workdir.path }}/prometheus-{{ prometheus__server_binary_version }}.linux-amd64/prometheus"
+    src: "{{ __prometheus_server_install_workdir.path }}/prometheus-{{ sitewards__prometheus__server_binary_version }}.linux-amd64/prometheus"
     dest: "/usr/local/bin/prometheus"
     owner: "root"
     group: "root"

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -7,7 +7,7 @@
     src: "etc/default/defaults.j2"
     dest: "/etc/default/prometheus"
   vars:
-    __prometheus__args: "{{ prometheus__server_args }}"
+    __sitewards__prometheus__args: "{{ sitewards__prometheus__server_args }}"
   notify: "restart prometheus-server"
 
 - name: "Create the etc directory"

--- a/templates/etc/default/defaults.j2
+++ b/templates/etc/default/defaults.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment('plain') }}
 
-ARGS='{{ __prometheus__args | join(' ')}}'
+ARGS='{{ __sitewards__prometheus__args | join(' ')}}'


### PR DESCRIPTION
More recent styleguides require variables to include a vendor prefix
(sitewards__) in addition to the role prefix. This commit adds such a
prefix.