### PR TITLE
AD-HOC feat (configuration): Allow templating some configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,26 @@ sitewards__prometheus__server_binary_version: "2.3.0"
 ##
 sitewards__prometheus__server_binary_sha256sum: "f806357db68a493ebd0ef24bb3cca550ee245831b306bde055253513bcb93496"
 
+##
+## The URL for alert manager
+## (Optional)
+sitewards__prometheus__server_alertmanager_urls: []
+
+##
+## The scrape configuration for the server
+## (Required)
+sitewards__prometheus__server_scrape_config:
+  - job_name: "prometheus"
+    scrape_interface: 5s
+    scrape_timeout: 5s
+    static_configs:
+      - targets:
+          - "localhost:9090"
+  - job_name: "node"
+    static_configs:
+      - targets:
+          - "localhost:9100"
+
 ## The version of the binary to install
 ##
 ## See

--- a/templates/etc/prometheus/prometheus.yml
+++ b/templates/etc/prometheus/prometheus.yml
@@ -10,11 +10,16 @@ global:
   external_labels:
       monitor: 'example'
 
+{% if sitewards__prometheus__server_alertmanager_urls|length > 0 %}
 # Alertmanager configuration
 alerting:
   alertmanagers:
   - static_configs:
-    - targets: ['localhost:9093']
+    - targets:
+{% for item in sitewards__prometheus__server_alertmanager_urls %}
+      - {{ item }}
+{% endfor %}
+{% endif %}
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
@@ -24,21 +29,22 @@ rule_files:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
+{% for job in sitewards__prometheus__server_scrape_config %}
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
-    scrape_timeout: 5s
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
+  - job_name: {{ job["job_name"] }}
+    {% if "scrape_interval" in job %}
+    scrape_interval: {{ job["scrape_interval"] }}
+    {% endif %}
+    {% if "scrape_timeout" in job %}
+    scrape_timeout: {{ job["scrape_timeout"] }}
+    {% endif %}
+    {% if "static_configs" in job %}
     static_configs:
-      - targets: ['localhost:9090']
-
-  - job_name: node
-    # If prometheus-node-exporter is installed, grab stats about the local
-    # machine by default.
-    static_configs:
-      - targets: ['localhost:9100']
+    {% for config in job["static_configs"] %}
+      - targets:
+        {% for target in config["targets"] %}
+          - {{ target }}
+        {% endfor %}
+    {% endfor %}
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
The Prometheus server is of limited use without being able to configure
the configuration. This commit allows configuring part of this
configuration.